### PR TITLE
Fixed context-root endpoint

### DIFF
--- a/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -6,7 +6,7 @@
 	version="1.0">
 
 	<reload-interval value="3"/>
-	<context-root uri="news-aggregator" />
+	<context-root uri="/" />
 	<enable-directory-browsing value="false"/>
 	<enable-file-serving value="true"/>
 	<enable-reloading value="true"/>


### PR DESCRIPTION
### Web application endpoint fixed
context-root in ibm-web-ext.xml resulted in the fixed url $YOUR_APP_ROUTE/news-aggregator
- context-root uri="/"
![fkkzj7r](https://cloud.githubusercontent.com/assets/13551199/8953540/959c1d96-35df-11e5-9614-f9a0287079da.jpg)
